### PR TITLE
Remove submit logic from click event handler

### DIFF
--- a/s3file/static/s3file/js/s3file.js
+++ b/s3file/static/s3file/js/s3file.js
@@ -80,7 +80,6 @@
   }
 
   function clickSubmit (e) {
-    e.preventDefault()
     let submitButton = e.target
     let form = submitButton.closest('form')
     const submitInput = document.createElement('input')
@@ -88,7 +87,6 @@
     submitInput.value = submitButton.value || true
     submitInput.name = submitButton.name
     form.appendChild(submitInput)
-    uploadS3Inputs(form)
   }
 
   function uploadS3Inputs (form) {


### PR DESCRIPTION
There is no need to have submit logic take place in the on click handler. It only deals with the mouse click event, *not* the submit event that will follow. 

Before this change, blocking the default action on the click event prevents a following submit event from taking place: `form.onsubmit` and other registered listeners waiting for a 'submit' will never be called.