### PR TITLE
Add event listeners in favor of overloading attributes

### DIFF
--- a/s3file/static/s3file/js/s3file.js
+++ b/s3file/static/s3file/js/s3file.js
@@ -106,13 +106,13 @@
     })
     forms = new Set(forms)
     forms.forEach(form => {
-      form.onsubmit = (e) => {
+      form.addEventListener('submit', (e) => {
         e.preventDefault()
         uploadS3Inputs(e.target)
-      }
+      })
       let submitButtons = form.querySelectorAll('input[type=submit], button[type=submit]')
       Array.from(submitButtons).forEach(submitButton => {
-        submitButton.onclick = clickSubmit
+        submitButton.addEventListener('click',  clickSubmit)
       }
       )
     })


### PR DESCRIPTION
Overloading the onsubmit or onclick attribute and collide with
other libraries that might do the same mistake. In this case
the last executed script would overwrite the privious listener.