### PR TITLE
Fix content-type POST conditions

### DIFF
--- a/s3file/forms.py
+++ b/s3file/forms.py
@@ -54,15 +54,12 @@ class S3FileInputMixin:
             ["starts-with", "$key", self.upload_folder],
             {"success_action_status": "201"},
         ]
-        if accept:
-            accept = accept.replace(' ', '')  # remove whitespaces
-            mime_types = accept.split(',') if accept else []  # catch empty string
-            for mime_type in mime_types:
-                top_type, sub_type = mime_type.split('/', 1)
-                if sub_type == '*':
-                    conditions.append(["starts-with", "$Content-Type", "%s/" % top_type])
-                else:
-                    conditions.append({"Content-Type": mime_type})
+        if accept and ',' not in accept:
+            top_type, sub_type = accept.split('/', 1)
+            if sub_type == '*':
+                conditions.append(["starts-with", "$Content-Type", "%s/" % top_type])
+            else:
+                conditions.append({"Content-Type": accept})
         else:
             conditions.append(["starts-with", "$Content-Type", ""])
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -119,17 +119,10 @@ class TestS3FileInput:
 
         widget = ClearableFileInput(attrs={'accept': 'application/pdf,image/*'})
         assert 'accept="application/pdf,image/*"' in widget.render(name='file', value='test.jpg')
-        assert ["starts-with", "$Content-Type", "image/"] in widget.get_conditions(
+        assert ["starts-with", "$Content-Type", ""] in widget.get_conditions(
             'application/pdf,image/*')
-        assert {"Content-Type": 'application/pdf'} in widget.get_conditions(
+        assert {"Content-Type": 'application/pdf'} not in widget.get_conditions(
             'application/pdf,image/*')
-
-        widget = ClearableFileInput(attrs={'accept': 'application/pdf, image/*'})
-        assert 'accept="application/pdf, image/*"' in widget.render(name='file', value='test.jpg')
-        assert ["starts-with", "$Content-Type", "image/"] in widget.get_conditions(
-            'application/pdf, image/*')
-        assert {"Content-Type": 'application/pdf'} in widget.get_conditions(
-            'application/pdf, image/*')
 
     def test_no_js_error(self, driver, live_server):
         driver.get(live_server + self.url)


### PR DESCRIPTION
POST conditions seem to be exclusive, so all conditions have to
match not only one of them. Therefore we need to remove the
condition if multiple content types are expected.