### PR TITLE
Fix #104 –– Add support for custom AWS_LOCATION or S3Boto3Storage.location

### DIFF
--- a/s3file/forms.py
+++ b/s3file/forms.py
@@ -5,6 +5,7 @@ import uuid
 
 from django.conf import settings
 from django.utils.functional import cached_property
+from storages.utils import safe_join
 
 from s3file.storages import storage
 
@@ -18,6 +19,7 @@ class S3FileInputMixin:
     upload_path = getattr(
         settings, 'S3FILE_UPLOAD_PATH', pathlib.PurePosixPath('tmp', 's3file')
     )
+    upload_path = safe_join(storage.location, upload_path)
     expires = settings.SESSION_COOKIE_AGE
 
     @property

--- a/s3file/middleware.py
+++ b/s3file/middleware.py
@@ -29,6 +29,7 @@ class S3FileMiddleware:
     def get_files_from_storage(paths):
         """Return S3 file where the name does not include the path."""
         for path in paths:
+            path = path.replace(os.path.dirname(storage.location) + '/', '', 1)
             try:
                 f = storage.open(path)
                 f.name = os.path.basename(path)

--- a/s3file/storages.py
+++ b/s3file/storages.py
@@ -2,12 +2,21 @@ import base64
 import datetime
 import hmac
 import json
+import os
 
 from django.conf import settings
 from django.core.files.storage import FileSystemStorage, default_storage
+from django.utils._os import safe_join
 
 
 class S3MockStorage(FileSystemStorage):
+    @property
+    def location(self):
+        return settings.AWS_LOCATION
+
+    def path(self, name):
+        return safe_join(os.path.abspath(self.base_location), self.location, name)
+
     class connection:
         class meta:
             class client:

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -53,3 +53,4 @@ AWS_STORAGE_BUCKET_NAME = 'test-bucket'
 AWS_S3_REGION_NAME = 'eu-central-1'
 AWS_S3_SIGNATURE_VERSION = 's3v4'
 AWS_DEFAULT_ACL = None
+AWS_LOCATION = 'custom/location/'


### PR DESCRIPTION
This fix is for users who have set `S3Boto3Storage.location` to anything other than the default value of empty string. We just have to prepend `default_storage.location` to `upload_path` in `forms.py` so the `input`-tag gets it client-side then strip it back out before passing to `default_storage.open(path)` in `middleware.py`. We have to strip it out before this because [`S3Boto3Storage._normalize_name()`](https://github.com/jschneier/django-storages/blob/master/storages/backends/s3boto3.py#L424) will prepend the location to the path (as it should).