### PR TITLE
Feature request #107: Add support for directory upload

### DIFF
--- a/s3file/forms.py
+++ b/s3file/forms.py
@@ -5,6 +5,7 @@ import uuid
 
 from django.conf import settings
 from django.utils.functional import cached_property
+from storages.utils import safe_join
 
 from s3file.storages import storage
 
@@ -18,6 +19,7 @@ class S3FileInputMixin:
     upload_path = getattr(
         settings, 'S3FILE_UPLOAD_PATH', pathlib.PurePosixPath('tmp', 's3file')
     )
+    upload_path = safe_join(storage.location, upload_path)
     expires = settings.SESSION_COOKIE_AGE
 
     @property

--- a/s3file/middleware.py
+++ b/s3file/middleware.py
@@ -29,6 +29,7 @@ class S3FileMiddleware:
     def get_files_from_storage(paths):
         """Return S3 file where the name does not include the path."""
         for path in paths:
+            path = path.replace(os.path.dirname(storage.location) + '/', '', 1)
             try:
                 f = storage.open(path)
                 f.name = os.path.basename(path)

--- a/s3file/static/s3file/js/s3file.js
+++ b/s3file/static/s3file/js/s3file.js
@@ -68,12 +68,19 @@
 
   function uploadFiles (form, fileInput, name) {
     var url = fileInput.getAttribute('data-url')
+    var fieldsKey = fileInput.getAttribute('data-fields-key')
     fileInput.loaded = 0
     fileInput.total = 0
     var promises = Array.from(fileInput.files).map(function (file) {
       form.total += file.size
       fileInput.total += file.size
       var s3Form = new window.FormData()
+      var dirname = file.webkitRelativePath.substr(
+        0, file.webkitRelativePath.lastIndexOf('/') + 1
+      )
+      fileInput.attributes.getNamedItem('data-fields-key').value = fieldsKey.substr(
+        0, fieldsKey.lastIndexOf('/') + 1
+      ) + dirname + fieldsKey.substr(fieldsKey.lastIndexOf('/') + 1)
       Array.from(fileInput.attributes).forEach(function (attr) {
         var name = attr.name
 

--- a/s3file/storages.py
+++ b/s3file/storages.py
@@ -2,12 +2,21 @@ import base64
 import datetime
 import hmac
 import json
+import os
 
 from django.conf import settings
 from django.core.files.storage import FileSystemStorage, default_storage
+from django.utils._os import safe_join
 
 
 class S3MockStorage(FileSystemStorage):
+    @property
+    def location(self):
+        return settings.AWS_LOCATION
+
+    def path(self, name):
+        return safe_join(os.path.abspath(self.base_location), self.location, name)
+
     class connection:
         class meta:
             class client:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import tempfile
 
 import pytest
@@ -12,6 +13,8 @@ from selenium.common.exceptions import WebDriverException
 def driver():
     chrome_options = webdriver.ChromeOptions()
     chrome_options.headless = True
+    if sys.platform.startswith('linux') and os.path.exists('/usr/bin/chromium'):
+        chrome_options.binary_location = '/usr/bin/chromium'
     try:
         b = webdriver.Chrome(options=chrome_options)
     except WebDriverException as e:
@@ -19,6 +22,18 @@ def driver():
     else:
         yield b
         b.quit()
+
+
+@pytest.fixture
+def upload_directory(request):
+    path = tempfile.mkdtemp()
+    file_name1 = os.path.join(path, '%s_1.txt' % request.node.name)
+    file_name2 = os.path.join(path, '%s_2.txt' % request.node.name)
+    file_names = [file_name1, file_name2]
+    for name in file_names:
+        with open(name, 'w') as f:
+            f.write(request.node.name)
+    return path
 
 
 @pytest.fixture

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -148,6 +148,20 @@ class TestS3FileInput:
             error = driver.find_element_by_xpath('//body[@JSError]')
             pytest.fail(error.get_attribute('JSError'))
 
+    def test_directory_insert(self, request, driver, live_server, upload_directory, freeze):
+        driver.get(live_server + reverse('upload_directory'))
+        file_input = driver.find_element_by_xpath('//input[@name=\'file\']')
+        file_input.send_keys(upload_directory)
+        assert file_input.get_attribute('name') == 'file'
+        with wait_for_page_load(driver, timeout=10):
+            file_input.submit()
+        assert storage.exists('tmp/%s/%s_1.txt' % (upload_directory, request.node.name))
+        assert storage.exists('tmp/%s/%s_2.txt' % (upload_directory, request.node.name))
+
+        with pytest.raises(NoSuchElementException):
+            error = driver.find_element_by_xpath('//body[@JSError]')
+            pytest.fail(error.get_attribute('JSError'))
+
     def test_file_insert_submit_value(self, driver, live_server, upload_file, freeze):
         driver.get(live_server + self.url)
         file_input = driver.find_element_by_xpath('//input[@name=\'file\']')

--- a/tests/testapp/forms.py
+++ b/tests/testapp/forms.py
@@ -16,3 +16,12 @@ class UploadForm(forms.ModelForm):
         widgets = {
             'file': forms.ClearableFileInput(attrs={'multiple': True}),
         }
+
+
+class UploadFormDirectory(forms.ModelForm):
+    class Meta:
+        model = FileModel
+        fields = ('file', 'other_file')
+        widgets = {
+            'file': forms.ClearableFileInput(attrs={'webkitdirectory': True}),
+        }

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -53,3 +53,4 @@ AWS_STORAGE_BUCKET_NAME = 'test-bucket'
 AWS_S3_REGION_NAME = 'eu-central-1'
 AWS_S3_SIGNATURE_VERSION = 's3v4'
 AWS_DEFAULT_ACL = None
+AWS_LOCATION = 'custom/location/'

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -4,4 +4,5 @@ from . import views
 
 urlpatterns = [
     path('', views.ExampleFormView.as_view(), name='upload'),
+    path('', views.UploadFormDirectoryView.as_view(), name='upload_directory'),
 ]

--- a/tests/testapp/views.py
+++ b/tests/testapp/views.py
@@ -25,3 +25,7 @@ class ExampleFormView(generic.FormView):
                 'other_file': self.request.FILES.getlist('other_file'),
             }
         }, status=201, encoder=FileEncoder)
+
+
+class UploadFormDirectoryView(ExampleFormView):
+    form_class = forms.UploadFormDirectory


### PR DESCRIPTION
The tests are still in progress. I am not sure why but request.FILES is empty in the view even though the directory and all files contained are sent to storage.