### PR TITLE
Convert CORS example to JSON

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,16 +92,23 @@ CORS policy
 You will need to allow ``POST`` from all origins. Just add the following
 to your CORS policy.
 
-.. code:: xml
+.. code:: json
 
-    <CORSConfiguration>
-        <CORSRule>
-            <AllowedOrigin>*</AllowedOrigin>
-            <AllowedMethod>POST</AllowedMethod>
-            <MaxAgeSeconds>3000</MaxAgeSeconds>
-            <AllowedHeader>*</AllowedHeader>
-        </CORSRule>
-    </CORSConfiguration>
+    [
+      {
+        "AllowedHeaders": [
+            "*"
+        ],
+        "AllowedMethods": [
+            "POST"
+        ],
+        "AllowedOrigins": [
+            "*"
+        ],
+        "ExposeHeaders": [],
+        "MaxAgeSeconds": 3000
+      }
+    ]
 
 Progress Bar
 ------------


### PR DESCRIPTION
S3 is moving to JSON CORS configuration rather than XML:

"In the new S3 console, the CORS configuration must be JSON"
 
https://docs.aws.amazon.com/AmazonS3/latest/userguide/enabling-cors-examples.html