### PR TITLE
Remove use of JSON in POST data

### DIFF
--- a/s3file/middleware.py
+++ b/s3file/middleware.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import pathlib
 
@@ -14,9 +13,9 @@ class S3FileMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        file_fields = json.loads(request.POST.get("s3file", "[]"))
+        file_fields = request.POST.getlist("s3file")
         for field_name in file_fields:
-            paths = json.loads(request.POST.get(field_name, "[]"))
+            paths = request.POST.getlist(field_name)
             request.FILES.setlist(field_name, list(self.get_files_from_storage(paths)))
 
         if local_dev and request.path == "/__s3_mock__/":

--- a/s3file/static/s3file/js/s3file.js
+++ b/s3file/static/s3file/js/s3file.js
@@ -88,14 +88,13 @@
       return request('POST', url, s3Form, fileInput, file, form)
     })
     Promise.all(promises).then(function (results) {
-      var keys = results.map(function (result) {
-        return parseURL(result)
+      results.forEach(function (result) {
+        var hiddenFileInput = document.createElement('input')
+        hiddenFileInput.type = 'hidden'
+        hiddenFileInput.name = name
+        hiddenFileInput.value = parseURL(result)
+        form.appendChild(hiddenFileInput)
       })
-      var hiddenFileInput = document.createElement('input')
-      hiddenFileInput.type = 'hidden'
-      hiddenFileInput.name = name
-      hiddenFileInput.value = JSON.stringify(keys)
-      form.appendChild(hiddenFileInput)
       fileInput.name = ''
       window.uploading -= 1
     }, function (err) {
@@ -120,13 +119,14 @@
     form.loaded = 0
     form.total = 0
     var inputs = Array.from(form.querySelectorAll('.s3file'))
-    var hiddenS3Input = document.createElement('input')
-    hiddenS3Input.type = 'hidden'
-    hiddenS3Input.name = 's3file'
-    form.appendChild(hiddenS3Input)
-    hiddenS3Input.value = JSON.stringify(inputs.map(function (input) {
-      return input.name
-    }))
+
+    inputs.forEach(function (input) {
+      var hiddenS3Input = document.createElement('input')
+      hiddenS3Input.type = 'hidden'
+      hiddenS3Input.name = 's3file'
+      hiddenS3Input.value = input.name
+      form.appendChild(hiddenS3Input)
+    })
     inputs.forEach(function (input) {
       window.uploading += 1
       uploadFiles(form, input, input.name)


### PR DESCRIPTION
First off, this is meant to be a conversation starter PR - I've had a hard time getting the tests passing locally so I'm not expecting them to pass with this change.

When working with this project and some custom JS for uplodaing (using FilePond), I found that the use of JSON might not be needed. If we create a form element with a duplicate name for each file uploaded then Django will convert that in to a list of values for us in `request.POST.getlist()`.

This suggestion removes the need to use JSON on the front or back end, and also makes generating the HTML needed for the middleware a little easier.