### PR TITLE
Replace call to self._clean_name with clean_name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "django>=2.0",
-    "django-storages",
+    "django-storages>=1.6",
     "boto3",
 ]
 

--- a/s3file/storages_optimized.py
+++ b/s3file/storages_optimized.py
@@ -1,4 +1,5 @@
 from storages.backends.s3boto3 import S3Boto3Storage
+from storages.utils import clean_name
 
 
 class S3OptimizedUploadStorage(S3Boto3Storage):
@@ -16,7 +17,7 @@ class S3OptimizedUploadStorage(S3Boto3Storage):
     def _save(self, name, content):
         # Basically copy the implementation of _save of S3Boto3Storage
         # and replace the obj.upload_fileobj with a copy function
-        cleaned_name = self._clean_name(name)
+        cleaned_name = clean_name(name)
         name = self._normalize_name(cleaned_name)
         params = self._get_write_parameters(name, content)
 


### PR DESCRIPTION
Fixes #251

This utility function was [moved in April 2017](https://github.com/jschneier/django-storages/commit/7cb67d57bfa9df3a28ca631da057b870a1cf201d), so it should be supported on all recent versions of django-storages, but it would break support for versions older than that. Should a minimum django-storages version be specified for django-s3file?