### PR TITLE
Use location var over env var

### DIFF
--- a/s3file/storages.py
+++ b/s3file/storages.py
@@ -57,4 +57,4 @@ storage = default_storage if not local_dev else S3MockStorage()
 
 
 def get_aws_location():
-    return getattr(settings, "AWS_LOCATION", "")
+    return storage.location or getattr(settings, "AWS_LOCATION", "")


### PR DESCRIPTION
Since you can set the location manually in the s3botostorage class we should choose that over the env variable. 